### PR TITLE
Fixes an issue where requesting an array from buildStationsTree returns only 1 element

### DIFF
--- a/nsapi.js
+++ b/nsapi.js
@@ -361,7 +361,7 @@ function buildStationsTree (data, treeKey) {
 
     if (treeKey === false) {
       tree.push (station);
-      break;
+      continue;
     }
 
     if (treeKey === 'code') {


### PR DESCRIPTION
When passing the argument false as treeKey to buildStationsTree, thus requesting an array, only 1 element would ever be returned due to the break statement. This fixes that issue.